### PR TITLE
Deep references: find references to descendant implementations

### DIFF
--- a/lib/Adapter/ReferenceFinder/IndexedImplementationFinder.php
+++ b/lib/Adapter/ReferenceFinder/IndexedImplementationFinder.php
@@ -35,11 +35,17 @@ class IndexedImplementationFinder implements ClassImplementationFinder
      */
     private $containerTypeResolver;
 
-    public function __construct(QueryClient $query, Reflector $reflector)
+    /**
+     * @var bool
+     */
+    private $deepReferences;
+
+    public function __construct(QueryClient $query, Reflector $reflector, bool $deepReferences = true)
     {
         $this->reflector = $reflector;
         $this->query = $query;
         $this->containerTypeResolver = new ContainerTypeResolver($reflector);
+        $this->deepReferences = $deepReferences;
     }
 
     /**
@@ -124,6 +130,11 @@ class IndexedImplementationFinder implements ClassImplementationFinder
         }
 
         foreach ($this->query->class()->implementing($type) as $implementingType) {
+            if (false === $this->deepReferences) {
+                yield $implementingType;
+                continue;
+            }
+
             yield from $this->resolveImplementations($implementingType, true);
         }
     }

--- a/lib/Adapter/ReferenceFinder/IndexedImplementationFinder.php
+++ b/lib/Adapter/ReferenceFinder/IndexedImplementationFinder.php
@@ -2,6 +2,8 @@
 
 namespace Phpactor\Indexer\Adapter\ReferenceFinder;
 
+use Generator;
+use Phpactor\Indexer\Adapter\ReferenceFinder\Util\ContainerTypeResolver;
 use Phpactor\Indexer\Model\QueryClient;
 use Phpactor\Name\FullyQualifiedName;
 use Phpactor\ReferenceFinder\ClassImplementationFinder;
@@ -13,6 +15,7 @@ use Phpactor\TextDocument\TextDocumentUri;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Inference\SymbolContext;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Reflector;
 
 class IndexedImplementationFinder implements ClassImplementationFinder
@@ -27,10 +30,16 @@ class IndexedImplementationFinder implements ClassImplementationFinder
      */
     private $query;
 
+    /**
+     * @var ContainerTypeResolver
+     */
+    private $containerTypeResolver;
+
     public function __construct(QueryClient $query, Reflector $reflector)
     {
         $this->reflector = $reflector;
         $this->query = $query;
+        $this->containerTypeResolver = new ContainerTypeResolver($reflector);
     }
 
     /**
@@ -47,16 +56,19 @@ class IndexedImplementationFinder implements ClassImplementationFinder
             return $this->methodImplementations($symbolContext);
         }
 
-        return new Locations(array_map(function (FullyQualifiedName $name) {
-            $record = $this->query->class()->get($name);
+        $locations = [];
+        $implementations = $this->resolveImplementations(FullyQualifiedName::fromString($symbolContext->type()->__toString()));
 
-            return new Location(
+        foreach ($implementations as $implementation) {
+            $record = $this->query->class()->get($implementation);
+
+            $locations[] = new Location(
                 TextDocumentUri::fromString($record->filePath()),
                 $record->start()
             );
-        }, $this->query->class()->implementing(
-            $symbolContext->type()->__toString()
-        )));
+        }
+
+        return new Locations($locations);
     }
 
     /**
@@ -65,24 +77,31 @@ class IndexedImplementationFinder implements ClassImplementationFinder
     private function methodImplementations(SymbolContext $symbolContext): Locations
     {
         $container = $symbolContext->containerType();
+        $methodName = $symbolContext->symbol()->name();
+        $containerType = $this->containerTypeResolver->resolveDeclaringContainerType('method', $methodName, $container);
 
-        if (null === $container) {
+        if (null === $containerType) {
             return new Locations([]);
         }
 
-        $implementations = $this->query->class()->implementing(
-            $container->__toString()
+        $implementations = $this->resolveImplementations(
+            FullyQualifiedName::fromString($containerType),
+            true
         );
 
-        $methodName = $symbolContext->symbol()->name();
         $locations = [];
 
         foreach ($implementations as $implementation) {
             $record = $this->query->class()->get($implementation);
             try {
-                $reflection = $this->reflector->reflectClassLike($implementation->__toString());
-                $method = $reflection->methods()->get($methodName);
+                $reflection = $this->reflector->reflectClass($implementation->__toString());
+                $method = $reflection->methods()->belongingTo($reflection->name())->get($methodName);
             } catch (NotFound $notFound) {
+                continue;
+            }
+
+            assert($method instanceof ReflectionMethod);
+            if ($method->isAbstract()) {
                 continue;
             }
 
@@ -93,5 +112,19 @@ class IndexedImplementationFinder implements ClassImplementationFinder
         }
 
         return new Locations($locations);
+    }
+
+    /**
+     * @return Generator<FullyQualifiedName>
+     */
+    private function resolveImplementations(FullyQualifiedName $type, bool $yieldFirst = false): Generator
+    {
+        if ($yieldFirst) {
+            yield $type;
+        }
+
+        foreach ($this->query->class()->implementing($type) as $implementingType) {
+            yield from $this->resolveImplementations($implementingType, true);
+        }
     }
 }

--- a/lib/Adapter/ReferenceFinder/IndexedReferenceFinder.php
+++ b/lib/Adapter/ReferenceFinder/IndexedReferenceFinder.php
@@ -4,7 +4,6 @@ namespace Phpactor\Indexer\Adapter\ReferenceFinder;
 
 use Generator;
 use Phpactor\Indexer\Adapter\ReferenceFinder\Util\ContainerTypeResolver;
-use Phpactor\Indexer\Adapter\ReferenceFinder\Util\ReflectionMemberResolver;
 use Phpactor\Indexer\Model\QueryClient;
 use Phpactor\Indexer\Model\LocationConfidence;
 use Phpactor\ReferenceFinder\PotentialLocation;

--- a/lib/Adapter/ReferenceFinder/IndexedReferenceFinder.php
+++ b/lib/Adapter/ReferenceFinder/IndexedReferenceFinder.php
@@ -32,11 +32,17 @@ class IndexedReferenceFinder implements ReferenceFinder
      */
     private $containerTypeResolver;
 
-    public function __construct(QueryClient $query, Reflector $reflector, ?ContainerTypeResolver $containerTypeResolver = null)
+    /**
+     * @var bool
+     */
+    private $deepReferences;
+
+    public function __construct(QueryClient $query, Reflector $reflector, ?ContainerTypeResolver $containerTypeResolver = null, bool $deepReferences = true)
     {
         $this->reflector = $reflector;
         $this->query = $query;
         $this->containerTypeResolver = $containerTypeResolver ?: new ContainerTypeResolver($reflector);
+        $this->deepReferences = $deepReferences;
     }
 
     /**
@@ -75,7 +81,9 @@ class IndexedReferenceFinder implements ReferenceFinder
     {
         $symbolType = $symbolContext->symbol()->symbolType();
         if ($symbolType === Symbol::CLASS_) {
-            yield from $this->query->class()->referencesTo($symbolContext->type()->__toString());
+            foreach ($this->implementationsOf($symbolContext->type()->__toString()) as $implementationFqn) {
+                yield from $this->query->class()->referencesTo($implementationFqn);
+            }
             return;
         }
 
@@ -89,16 +97,47 @@ class IndexedReferenceFinder implements ReferenceFinder
             Symbol::CONSTANT,
             Symbol::PROPERTY
         ])) {
-            yield from $this->query->member()->referencesTo(
+            $containerType = $this->containerTypeResolver->resolveDeclaringContainerType(
                 $symbolContext->symbol()->symbolType(),
                 $symbolContext->symbol()->name(),
-                $this->containerTypeResolver->resolveDeclaringContainerType(
+                $symbolContext->containerType()
+            );
+
+            if (null === $containerType) {
+                yield from $this->query->member()->referencesTo(
                     $symbolContext->symbol()->symbolType(),
                     $symbolContext->symbol()->name(),
-                    $symbolContext->containerType()
-                )
-            );
+                    null
+                );
+                return;
+            }
+
+            // note that we check the all implementations: this will multiply
+            // the number of NOT and MAYBE matches
+            foreach ($this->implementationsOf($containerType) as $containerType) {
+                yield from $this->query->member()->referencesTo(
+                    $symbolContext->symbol()->symbolType(),
+                    $symbolContext->symbol()->name(),
+                    $containerType
+                );
+            }
             return;
+        }
+    }
+
+    /**
+     * @return Generator<string>
+     */
+    private function implementationsOf(string $fqn): Generator
+    {
+        yield $fqn;
+
+        if (false === $this->deepReferences) {
+            return;
+        }
+
+        foreach ($this->query->class()->implementing($fqn) as $implementation) {
+            yield from $this->implementationsOf($implementation->__toString());
         }
     }
 }

--- a/lib/Adapter/ReferenceFinder/Util/ContainerTypeResolver.php
+++ b/lib/Adapter/ReferenceFinder/Util/ContainerTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Phpactor\Indexer\Adapter\ReferenceFinder\Util;
+
+use Phpactor\WorseReflection\Core\Exception\NotFound;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
+use Phpactor\WorseReflection\Core\Reflector\ClassReflector;
+use Phpactor\WorseReflection\Core\Type;
+
+class ContainerTypeResolver
+{
+    /**
+     * @var ClassReflector
+     */
+    private $reflector;
+
+    public function __construct(ClassReflector $reflector)
+    {
+        $this->reflector = $reflector;
+    }
+
+    public function resolveDeclaringContainerType(string $memberType, string $memberName, ?string $containerFqn): ?string
+    {
+        if (null === $containerFqn) {
+            return null;
+        }
+
+        try {
+            $classLike = $this->reflector->reflectClassLike($containerFqn);
+            $members = $classLike->members()->byMemberType($memberType);
+
+            return $members->get($memberName)->original()->declaringClass()->name()->__toString();
+        } catch (NotFound $notFound) {
+            return $containerFqn;
+        }
+
+    }
+}

--- a/lib/Adapter/ReferenceFinder/Util/ContainerTypeResolver.php
+++ b/lib/Adapter/ReferenceFinder/Util/ContainerTypeResolver.php
@@ -3,10 +3,7 @@
 namespace Phpactor\Indexer\Adapter\ReferenceFinder\Util;
 
 use Phpactor\WorseReflection\Core\Exception\NotFound;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 use Phpactor\WorseReflection\Core\Reflector\ClassReflector;
-use Phpactor\WorseReflection\Core\Type;
 
 class ContainerTypeResolver
 {
@@ -34,6 +31,5 @@ class ContainerTypeResolver
         } catch (NotFound $notFound) {
             return $containerFqn;
         }
-
     }
 }

--- a/tests/Adapter/ReferenceFinder/IndexedImplementationFinderTest.php
+++ b/tests/Adapter/ReferenceFinder/IndexedImplementationFinderTest.php
@@ -87,6 +87,21 @@ EOT
         ,
             2
         ];
+
+        yield 'implementations of abstract class implementation' => [
+            <<<'EOT'
+// File: project/subject.php
+<?php abstract class Fo<>o {}
+// File: project/class.php
+<?php
+
+class Foobar extends Foo {}
+class Barfoo extends Foo {}
+class Carfoo extends Barfoo {}
+EOT
+        ,
+            3
+        ];
     }
 
     /**
@@ -125,17 +140,38 @@ EOT
             2
         ];
 
-        yield 'class member' => [
+        yield 'does not count abstract class member' => [
             <<<'EOT'
 // File: project/subject.php
-<?php class Foo {
-   public function doT<>his();
+<?php abstract class Foo {
+   abstract public function doT<>his();
 }
 // File: project/class.php
 <?php
 
 class Foobar extends Foo {
     public function doThis();
+}
+EOT
+        ,
+            1
+        ];
+
+        yield 'member implementations of abstract class implementation' => [
+            <<<'EOT'
+// File: project/subject.php
+<?php $foo = new Foo();
+   $foo->d<>oThis();
+}
+// File: project/class.php
+<?php
+class Bar {
+    public function doThis();
+}
+
+// File: project/foo.php
+<?php
+class Foo extends Bar {
 }
 EOT
         ,

--- a/tests/Unit/Adapter/ReferenceFinder/Util/ContainerTypeResolverTest.php
+++ b/tests/Unit/Adapter/ReferenceFinder/Util/ContainerTypeResolverTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Phpactor\Indexer\Tests\Unit\Adapter\ReferenceFinder\Util;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Indexer\Adapter\ReferenceFinder\Util\ContainerTypeResolver;
+use Phpactor\Indexer\Tests\IntegrationTestCase;
+use Phpactor\TestUtils\ExtractOffset;
+
+class ContainerTypeResolverTest extends IntegrationTestCase
+{
+    /**
+     * @dataProvider provideResolve
+     */
+    public function testResolve(
+        array $manifest,
+        string $memberType,
+        string $memberName,
+        ?string $containerType,
+        ?string $expectedType
+    )
+    {
+        $this->workspace()->reset();
+        $this->workspace()->loadManifest(implode("\n", $manifest));
+        $source = $this->workspace()->getContents('test.php');
+        [$source, $offset] = ExtractOffset::fromSource($source);
+
+        $type = (new ContainerTypeResolver($this->createReflector()))->resolveDeclaringContainerType(
+            $memberType,
+            $memberName,
+            $containerType
+        );
+
+        self::assertEquals($expectedType, $type);
+    }
+
+    /**
+     * @return Generator<mixed>
+     */
+    public function provideResolve(): Generator
+    {
+        yield 'no container type' => [
+            ["// File: test.php\n"],
+            'method',
+            'foobar',
+            null,
+            null
+        ];
+
+        yield 'declaring container type' => [
+            ["// File: test.php\n<?php class Foobar { public function barfoo() {}}"],
+            'method',
+            'barfoo',
+            'Foobar',
+            'Foobar',
+        ];
+
+        yield 'parent container type' => [
+            [
+                "// File: test.php\n<?php class Foobar { public function barfoo() {}}",
+                "// File: one.php\n<?php class Barfoo extends Foobar {}",
+            ],
+            'method',
+            'barfoo',
+            'Barfoo',
+            'Foobar',
+        ];
+
+        yield 'parent container type with overridden type' => [
+            [
+                "// File: test.php\n<?php class Foobar { public function barfoo() {}}",
+                "// File: one.php\n<?php class Barfoo extends Foobar { public function barfoo() {}}",
+            ],
+            'method',
+            'barfoo',
+            'Barfoo',
+            'Foobar',
+        ];
+
+        yield 'parent or parent container type with overridden type' => [
+            [
+                "// File: test.php\n<?php class Foobar { public function barfoo() {}}",
+                "// File: one.php\n<?php class Barfoo extends Foobar { public function barfoo() {}}",
+                "// File: two.php\n<?php class Carfoo extends Barfoo { public function barfoo() {}}",
+            ],
+            'method',
+            'barfoo',
+            'Carfoo',
+            'Foobar',
+        ];
+
+        yield 'interface method' => [
+            [
+                "// File: test.php\n<?php interface Foobar { public function barfoo() {}}",
+                "// File: one.php\n<?php class Barfoo implements Foobar { public function barfoo() {}}",
+            ],
+            'method',
+            'barfoo',
+            'Barfoo',
+            'Foobar',
+        ];
+    }
+}


### PR DESCRIPTION
Previously only those classes with direct references to an FQN would be found in the reference search.

Now:

- For class references: Find all references to the target class/interface or any descendant classes/interface implementing it
- For method references: Find "original" method declaration and then find all references in all implemenations of the class.
- For implementation finding: Consider all descendant classes (so search for `Throwable` will return all exceptions in the project f.e.).  

