### PR TITLE
Support for including stub paths

### DIFF
--- a/lib/Adapter/Filesystem/FilesystemFileListProvider.php
+++ b/lib/Adapter/Filesystem/FilesystemFileListProvider.php
@@ -14,7 +14,7 @@ class FilesystemFileListProvider implements FileListProvider
     /**
      * @var array<string>
      */
-    private $excludePatterns = [];
+    private $excludePatterns;
 
     /**
      * @var array<string>

--- a/lib/Extension/Command/IndexSearchCommand.php
+++ b/lib/Extension/Command/IndexSearchCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Phpactor\Indexer\Extension\Command;
+
+use Phpactor\Indexer\Model\Query\Criteria;
+use Phpactor\Indexer\Model\Query\Criteria\ShortNameBeginsWith;
+use Phpactor\Indexer\Model\RecordReference;
+use Phpactor\Indexer\Model\Record\ClassRecord;
+use Phpactor\Indexer\Model\Record\FunctionRecord;
+use Phpactor\Indexer\Model\Record\MemberRecord;
+use Phpactor\Indexer\Model\QueryClient;
+use Phpactor\Indexer\Model\SearchClient;
+use Phpactor\Indexer\Util\Cast;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class IndexSearchCommand extends Command
+{
+    const ARG_SEARCH = 'search';
+
+    /**
+     * @var SearchClient
+     */
+    private $searchClient;
+
+    public function __construct(SearchClient $searchClient)
+    {
+        parent::__construct();
+        $this->searchClient = $searchClient;
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument(self::ARG_SEARCH, InputArgument::REQUIRED, 'Search text');
+        $this->setDescription(
+            'Search the index'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $search = $input->getArgument(self::ARG_SEARCH);
+        assert(is_string($search));
+
+        $criteria = new ShortNameBeginsWith($search);
+        foreach ($this->searchClient->search($criteria) as $result) {
+            $output->writeln(sprintf('<comment>%s</> <fg=cyan>#</> %s', $result->recordType(), $result->identifier()));
+        }
+        return 0;
+    }
+}

--- a/lib/Extension/IndexerExtension.php
+++ b/lib/Extension/IndexerExtension.php
@@ -193,12 +193,10 @@ class IndexerExtension implements Extension
             );
             return IndexAgentBuilder::create($indexPath, $this->projectRoot($container))
                 ->setExcludePatterns($container->get(self::SERVICE_INDEXER_EXCLUDE_PATTERNS))
-                ->setIncludePatterns(array_merge(
+                ->setIncludePatterns(
                     $container->get(self::SERVICE_INDEXER_INCLUDE_PATTERNS),
-                    array_map(function (string $path) use ($resolver) {
-                        return $resolver->resolve($path);
-                    }, $container->getParameter(self::PARAM_STUB_PATHS))
-                ));
+                )
+                ->setStubPaths($container->getParameter(self::PARAM_STUB_PATHS));
         });
 
         $container->register(Indexer::class, function (Container $container) {

--- a/lib/Extension/IndexerExtension.php
+++ b/lib/Extension/IndexerExtension.php
@@ -29,6 +29,7 @@ use Phpactor\Indexer\Adapter\Worse\IndexerClassSourceLocator;
 use Phpactor\Indexer\Adapter\Worse\IndexerFunctionSourceLocator;
 use Phpactor\Indexer\Adapter\ReferenceFinder\IndexedReferenceFinder;
 use Phpactor\Indexer\Adapter\Worse\WorseRecordReferenceEnhancer;
+use Phpactor\Indexer\Extension\Command\IndexSearchCommand;
 use Phpactor\Indexer\IndexAgent;
 use Phpactor\Indexer\IndexAgentBuilder;
 use Phpactor\Indexer\Model\IndexAccess;
@@ -159,6 +160,10 @@ class IndexerExtension implements Extension
         $container->register(IndexQueryCommand::class, function (Container $container) {
             return new IndexQueryCommand($container->get(QueryClient::class));
         }, [ ConsoleExtension::TAG_COMMAND => ['name' => 'index:query']]);
+
+        $container->register(IndexSearchCommand::class, function (Container $container) {
+            return new IndexSearchCommand($container->get(SearchClient::class));
+        }, [ ConsoleExtension::TAG_COMMAND => ['name' => 'index:search']]);
     }
 
     private function registerModel(ContainerBuilder $container): void

--- a/lib/Model/FileList.php
+++ b/lib/Model/FileList.php
@@ -2,11 +2,15 @@
 
 namespace Phpactor\Indexer\Model;
 
+use AppendIterator;
 use ArrayIterator;
 use Countable;
 use Iterator;
 use IteratorAggregate;
+use MultipleIterator;
 use SplFileInfo;
+
+
 
 /**
  * @implements \IteratorAggregate<SplFileInfo>
@@ -26,6 +30,11 @@ class FileList implements IteratorAggregate, Countable
         $this->splFileInfos = new ArrayIterator(iterator_to_array($splFileInfos));
     }
 
+    public static function empty(): self
+    {
+        return new self(new ArrayIterator([]));
+    }
+
     /**
      * @param Iterator<SplFileInfo> $splFileInfos
      */
@@ -37,6 +46,15 @@ class FileList implements IteratorAggregate, Countable
     public static function fromSingleFilePath(?string $subPath): self
     {
         return new self(new ArrayIterator([ new SplFileInfo($subPath) ]));
+    }
+
+    public function merge(FileList $fileList): self
+    {
+        $iterator = new AppendIterator();
+        $iterator->append($this->splFileInfos);
+        $iterator->append($fileList->splFileInfos);
+
+        return new self($iterator);
     }
 
     /**

--- a/lib/Model/FileListProvider/ChainFileListProvider.php
+++ b/lib/Model/FileListProvider/ChainFileListProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Phpactor\Indexer\Model\FileListProvider;
+
+use Phpactor\Indexer\Model\FileList;
+use Phpactor\Indexer\Model\FileListProvider;
+use Phpactor\Indexer\Model\Index;
+
+class ChainFileListProvider implements FileListProvider
+{
+    /**
+     * @var array<FileListProvider>
+     */
+    private $providers;
+
+    public function __construct(FileListProvider ...$providers)
+    {
+        $this->providers = $providers;
+    }
+
+    public function provideFileList(Index $index, ?string $subPath = null): FileList
+    {
+        $fileList = FileList::empty();
+        foreach ($this->providers as $provider) {
+            $fileList = $fileList->merge($provider->provideFileList($index, $subPath));
+        }
+
+        return $fileList;
+    }
+}

--- a/lib/Model/IndexJob.php
+++ b/lib/Model/IndexJob.php
@@ -36,6 +36,7 @@ class IndexJob
 
     public function run(): void
     {
+        /** @phpstan-ignore-next-line */
         iterator_to_array($this->generator());
     }
 


### PR DESCRIPTION
The existing stub support doesn't work, as the paths must be relative to the project root (I think - or possibly just can't be interpreted as globs).

This PR adds a chain file list provider and a dedicated provider for all stub paths.