### PR TITLE
Fix strange behavior

### DIFF
--- a/lib/Extension/Command/IndexSearchCommand.php
+++ b/lib/Extension/Command/IndexSearchCommand.php
@@ -2,15 +2,8 @@
 
 namespace Phpactor\Indexer\Extension\Command;
 
-use Phpactor\Indexer\Model\Query\Criteria;
 use Phpactor\Indexer\Model\Query\Criteria\ShortNameBeginsWith;
-use Phpactor\Indexer\Model\RecordReference;
-use Phpactor\Indexer\Model\Record\ClassRecord;
-use Phpactor\Indexer\Model\Record\FunctionRecord;
-use Phpactor\Indexer\Model\Record\MemberRecord;
-use Phpactor\Indexer\Model\QueryClient;
 use Phpactor\Indexer\Model\SearchClient;
-use Phpactor\Indexer\Util\Cast;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
I noticed a strange behavior on a test project that I used locally.
My project was not indexed, only the stubs...
After debugging a bit it appears that the `AppendIterator` has some strange behavior and does not play nicely with `iterator_to_array` nor `iterator_count`.
So in addition to my own issue, that I can't reproduce on other project, we don't have the correct count.
We also use `iterator_to_array` in the constructor to protect ourselves in case we are provided with a Generator since we cant rewind them.

For all those reasons I think it would be better to handle the files information with a regular array.
This PR refactor the `FileList` to use array internally, the API in unchanged (except for the constructor that can also accept array now).

As mentioned on slack we should not suffer any performance lost since we used `iterator_to_array` in the constructor we were already having the full list in memory.

As a bonus it seems to also resolve the exception we got when trying to re-index with no changes:
```sh
phpactor index:build --reset && phpactor index:build
```
Does not trigger anymore exception.