### PR TITLE
Fix/#1113 index file outside project directory

### DIFF
--- a/lib/Extension/Command/IndexBuildCommand.php
+++ b/lib/Extension/Command/IndexBuildCommand.php
@@ -127,8 +127,16 @@ class IndexBuildCommand extends Command
      */
     private function formatMemory(int $memoryInBytes): string
     {
-        $unit = ['B', 'KiB', 'MiB', 'GiB'];
+        if (0 === $memoryInBytes) {
+            return '0 B';
+        }
 
-        return @round($memoryInBytes / pow(1024, ($i = floor(log($memoryInBytes, 1024)))), 2).' '.$unit[$i];
+        $unit = ['B', 'KiB', 'MiB'];
+        // Never exceed 2 since it's not handled
+        $factor = min(floor(log($memoryInBytes, 1024)), 2);
+        $orderOfMagnitude = pow(1024, $factor);
+        $memoryInUnit = $memoryInBytes / $orderOfMagnitude;
+
+        return sprintf('%.2f %s', $memoryInUnit, $unit[$factor]);
     }
 }

--- a/lib/Extension/Command/IndexBuildCommand.php
+++ b/lib/Extension/Command/IndexBuildCommand.php
@@ -93,9 +93,9 @@ class IndexBuildCommand extends Command
         $output->write(PHP_EOL);
 
         $output->writeln(sprintf(
-            '<bg=green;fg=black;option>Done in %s seconds using %sb of memory</>',
+            '<bg=green;fg=black;option>Done in %s seconds using %s of memory</>',
             number_format(microtime(true) - $start, 2),
-            number_format(memory_get_usage(true))
+            $this->formatMemory(memory_get_usage(true))
         ));
     }
 
@@ -120,5 +120,15 @@ class IndexBuildCommand extends Command
                 }
             }
         });
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/function.memory-get-usage.php#96280
+     */
+    private function formatMemory(int $memoryInBytes): string
+    {
+        $unit = ['B', 'KiB', 'MiB', 'GiB'];
+
+        return @round($memoryInBytes / pow(1024, ($i = floor(log($memoryInBytes, 1024)))), 2).' '.$unit[$i];
     }
 }

--- a/lib/IndexAgentBuilder.php
+++ b/lib/IndexAgentBuilder.php
@@ -56,7 +56,7 @@ final class IndexAgentBuilder
     /**
      * @var array<string>
      */
-    private $stubPaths = [];
+    private $externalSourcePaths = [];
 
     /**
      * @var array<string>
@@ -101,7 +101,7 @@ final class IndexAgentBuilder
 
     public function addStubPath(string $path): self
     {
-        $this->stubPaths[] = $path;
+        $this->externalSourcePaths[] = $path;
 
         return $this;
     }
@@ -236,9 +236,9 @@ final class IndexAgentBuilder
             )
         ];
 
-        foreach ($this->stubPaths as $stubPath) {
+        foreach ($this->externalSourcePaths as $externalSourcePath) {
             $providers[] = new FilesystemFileListProvider(
-                $this->buildFilesystem($stubPath)
+                $this->buildFilesystem($externalSourcePath)
             );
         }
 
@@ -246,11 +246,11 @@ final class IndexAgentBuilder
     }
 
     /**
-     * @param array<string> $stubPaths
+     * @param array<string> $externalSourcePaths
      */
-    public function setStubPaths(array $stubPaths): self
+    public function setExternalSourcePaths(array $externalSourcePaths): self
     {
-        $this->stubPaths = $stubPaths;
+        $this->externalSourcePaths = $externalSourcePaths;
 
         return $this;
     }


### PR DESCRIPTION
Fix https://github.com/phpactor/phpactor/issues/1113

Basically rename the constant and variables.
A little bonus is the human readable printing of the memory consumption in the console :smiley_cat: 

Should be merged in the same time as: https://github.com/phpactor/phpactor/pull/1123