### PR TITLE
Add search by fqn-begins-with

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -34,7 +34,7 @@ $container = PhpactorContainer::fromExtensions([
     IndexerExtension::PARAM_EXCLUDE_PATTERNS => ['cache'],
     IndexerExtension::PARAM_ENABLED_WATCHERS => ['watchman', 'find'],
     WorseReflectionExtension::PARAM_ENABLE_CACHE => true,
-    LoggingExtension::PARAM_ENABLED => true,
+    LoggingExtension::PARAM_ENABLED => false,
     LoggingExtension::PARAM_LEVEL => 'debug',
     LoggingExtension::PARAM_PATH=> 'php://stdout',
 ]);

--- a/lib/Extension/Command/IndexSearchCommand.php
+++ b/lib/Extension/Command/IndexSearchCommand.php
@@ -5,7 +5,6 @@ namespace Phpactor\Indexer\Extension\Command;
 use Phpactor\Indexer\Model\Query\Criteria;
 use Phpactor\Indexer\Model\SearchClient;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/lib/Extension/Command/IndexSearchCommand.php
+++ b/lib/Extension/Command/IndexSearchCommand.php
@@ -2,16 +2,28 @@
 
 namespace Phpactor\Indexer\Extension\Command;
 
+use Phpactor\Indexer\Model\Query\Criteria\AndCriteria;
+use Phpactor\Indexer\Model\Query\Criteria\FqnBeginsWith;
+use Phpactor\Indexer\Model\Query\Criteria\IsClass;
+use Phpactor\Indexer\Model\Query\Criteria\IsFunction;
+use Phpactor\Indexer\Model\Query\Criteria\IsMember;
 use Phpactor\Indexer\Model\Query\Criteria\ShortNameBeginsWith;
 use Phpactor\Indexer\Model\SearchClient;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class IndexSearchCommand extends Command
 {
     const ARG_SEARCH = 'search';
+    const OPT_FQN_BEGINS = 'fqn-begins';
+    const OPT_SHORT_NAME_BEGINS = 'short-name-begins';
+    const OPT_IS_FUNCTION = 'is-function';
+    const OPT_IS_CLASS = 'is-class';
+    const OPT_IS_MEMBER = 'is-member';
+
 
     /**
      * @var SearchClient
@@ -26,7 +38,11 @@ class IndexSearchCommand extends Command
 
     protected function configure(): void
     {
-        $this->addArgument(self::ARG_SEARCH, InputArgument::REQUIRED, 'Search text');
+        $this->addOption(self::OPT_FQN_BEGINS, null, InputOption::VALUE_REQUIRED, 'FQN begins with');
+        $this->addOption(self::OPT_SHORT_NAME_BEGINS, null, InputOption::VALUE_REQUIRED, 'Short-name begins with');
+        $this->addOption(self::OPT_IS_FUNCTION, null, InputOption::VALUE_NONE, 'Functions only');
+        $this->addOption(self::OPT_IS_CLASS, null, InputOption::VALUE_NONE, 'Classes only');
+        $this->addOption(self::OPT_IS_MEMBER, null, InputOption::VALUE_NONE, 'Is Member');
         $this->setDescription(
             'Search the index'
         );
@@ -34,13 +50,39 @@ class IndexSearchCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $search = $input->getArgument(self::ARG_SEARCH);
+        $shortNameBegins = $input->getOption(self::OPT_SHORT_NAME_BEGINS);
+        $fqnBegins = $input->getOption(self::OPT_FQN_BEGINS);
+        $isFunction = $input->getOption(self::OPT_IS_FUNCTION);
+        $isClass = $input->getOption(self::OPT_IS_CLASS);
+        $isMember = $input->getOption(self::OPT_IS_MEMBER);
         assert(is_string($search));
 
-        $criteria = new ShortNameBeginsWith($search);
-        foreach ($this->searchClient->search($criteria) as $result) {
+        $criterias = [];
+
+        if ($shortNameBegins) {
+            $criterias[] = new ShortNameBeginsWith($shortNameBegins);
+        }
+
+        if ($fqnBegins) {
+            $criterias[] = new FqnBeginsWith($fqnBegins);
+        }
+
+        if ($isFunction) {
+            $criterias[] = new IsFunction();
+        }
+
+        if ($isMember) {
+            $criterias[] = new IsMember();
+        }
+
+        if ($isClass) {
+            $criterias[] = new IsClass();
+        }
+
+        foreach ($this->searchClient->search(new AndCriteria(...$criterias)) as $result) {
             $output->writeln(sprintf('<comment>%s</> <fg=cyan>#</> %s', $result->recordType(), $result->identifier()));
         }
+
         return 0;
     }
 }

--- a/lib/Model/MemoryUsage.php
+++ b/lib/Model/MemoryUsage.php
@@ -45,7 +45,7 @@ final class MemoryUsage
         return sprintf('%s/%s mb', $this->formatMemory($this->memoryUsage), $this->formatMemory($this->memoryLimit));
     }
 
-    public function memoryLimit(): int
+    public function memoryLimit(): ?int
     {
         return $this->memoryLimit;
     }

--- a/lib/Model/Query/Criteria.php
+++ b/lib/Model/Query/Criteria.php
@@ -4,6 +4,7 @@ namespace Phpactor\Indexer\Model\Query;
 
 use Phpactor\Indexer\Model\Query\Criteria\AndCriteria;
 use Phpactor\Indexer\Model\Query\Criteria\ExactShortName;
+use Phpactor\Indexer\Model\Query\Criteria\FqnBeginsWith;
 use Phpactor\Indexer\Model\Query\Criteria\IsClass;
 use Phpactor\Indexer\Model\Query\Criteria\IsFunction;
 use Phpactor\Indexer\Model\Query\Criteria\IsMember;
@@ -23,6 +24,11 @@ abstract class Criteria
     public static function shortNameBeginsWith(string $name): ShortNameBeginsWith
     {
         return new ShortNameBeginsWith($name);
+    }
+
+    public static function fqnBeginsWith(string $name): FqnBeginsWith
+    {
+        return new FqnBeginsWith($name);
     }
 
     public static function and(Criteria ...$criterias): AndCriteria

--- a/lib/Model/Query/Criteria/FqnBeginsWith.php
+++ b/lib/Model/Query/Criteria/FqnBeginsWith.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phpactor\Indexer\Model\Query\Criteria;
+
+use Phpactor\Indexer\Model\Query\Criteria;
+use Phpactor\Indexer\Model\Record;
+use Phpactor\Indexer\Model\Record\HasFullyQualifiedName;
+
+class FqnBeginsWith extends Criteria
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function isSatisfiedBy(Record $record): bool
+    {
+        if (!$this->name) {
+            return false;
+        }
+
+        if (!$record instanceof HasFullyQualifiedName) {
+            return false;
+        }
+
+        return 0 === strpos($record->fqn()->__toString(), $this->name);
+    }
+}

--- a/tests/Extension/Command/IndexSearchCommandTest.php
+++ b/tests/Extension/Command/IndexSearchCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Phpactor\Indexer\Tests\Extension\Command;
+
+use Generator;
+use Phpactor\Indexer\Tests\IntegrationTestCase;
+use Symfony\Component\Process\Process;
+
+class IndexSearchCommandTest extends IntegrationTestCase
+{
+    /**
+     * @dataProvider provideQuery
+     */
+    public function testQueryIndex(array $args = []): void
+    {
+        $this->initProject();
+
+        $process = new Process(array_merge([
+            __DIR__ . '/../../../bin/console',
+            'index:search',
+        ], $args), $this->workspace()->path());
+        $process->mustRun();
+        self::assertEquals(0, $process->getExitCode());
+    }
+
+    /**
+     * @return Generator<mixed>
+     */
+    public function provideQuery(): Generator
+    {
+        yield 'all' => [
+            [
+                '--limit=1'
+            ]
+        ];
+
+        yield 'classes' => [
+            [
+                '--is-class',
+                '--is-function',
+                '--short-name=Foo',
+                '--short-name-begins=Foo',
+                '--fqn-begins=Foo',
+                '--limit=1'
+            ]
+        ];
+    }
+}

--- a/tests/Unit/Model/MemoryUsageTest.php
+++ b/tests/Unit/Model/MemoryUsageTest.php
@@ -10,8 +10,10 @@ class MemoryUsageTest extends TestCase
 {
     public function testMemoryLimit(): void
     {
-        $limit = MemoryUsage::create()->memoryLimit();
-        self::assertIsInt($limit);
+        MemoryUsage::create()->memoryLimit();
+
+        // the result is system dependent
+        $this->addToAssertionCount(1);
     }
 
     public function testMemoryUsage(): void

--- a/tests/Unit/Model/Query/Criteria/FqnBeginsWithTest.php
+++ b/tests/Unit/Model/Query/Criteria/FqnBeginsWithTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Phpactor\Indexer\Tests\Unit\Model\Query\Criteria;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Indexer\Model\Query\Criteria;
+use Phpactor\Indexer\Model\Query\Criteria\ShortNameBeginsWith;
+use Phpactor\Indexer\Model\Record\ClassRecord;
+
+class FqnBeginsWithTest extends TestCase
+{
+    public function testNotMatchesEmpty(): void
+    {
+        $record = ClassRecord::fromName('Foobar\\Barfoo');
+        self::assertTrue(Criteria::fqnBeginsWith('Foobar')->isSatisfiedBy($record));
+    }
+
+    public function testMatchesExact(): void
+    {
+        $record = ClassRecord::fromName('Foobar\\Barfoo');
+        self::assertTrue(Criteria::fqnBeginsWith('Foobar\\Barfoo')->isSatisfiedBy($record));
+    }
+
+    public function testNotMatches(): void
+    {
+        $record = ClassRecord::fromName('Foobar\\Bazfoo');
+        self::assertFalse(Criteria::fqnBeginsWith('Barfoo')->isSatisfiedBy($record));
+    }
+
+    public function testMatchesPartialBeginingWith(): void
+    {
+        $record = ClassRecord::fromName('Foobar\\Barfoos');
+        self::assertTrue(Criteria::fqnBeginsWith('Foo')->isSatisfiedBy($record));
+    }
+
+    public function testNotMatchesPartialEndsWith(): void
+    {
+        $record = ClassRecord::fromName('Foobar\\abBarfoo');
+        self::assertFalse(Criteria::fqnBeginsWith('Barfoo')->isSatisfiedBy($record));
+    }
+
+    public function testMatchesGlobal(): void
+    {
+        $record = ClassRecord::fromName('Barfoo');
+        self::assertTrue(Criteria::fqnBeginsWith('Barfoo')->isSatisfiedBy($record));
+    }
+}


### PR DESCRIPTION
- Adds support for search by "FQN begins with"
- Improves the `index:search` command to allow specifying types of criteria.

![image](https://user-images.githubusercontent.com/530801/100537594-b4967180-3221-11eb-8459-91c79161a9a2.png)


