### PR TITLE
Dirty file tracking

### DIFF
--- a/lib/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
@@ -13,7 +13,6 @@ use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\TextDocument\TextDocument;
-use SplFileInfo;
 
 abstract class AbstractClassLikeIndexer implements TolerantIndexer
 {

--- a/lib/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
@@ -12,11 +12,12 @@ use Phpactor\Indexer\Model\Name\FullyQualifiedName;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\Indexer\Model\Index;
+use Phpactor\TextDocument\TextDocument;
 use SplFileInfo;
 
 abstract class AbstractClassLikeIndexer implements TolerantIndexer
 {
-    public function beforeParse(Index $index, SplFileInfo $info): void
+    public function beforeParse(Index $index, TextDocument $document): void
     {
     }
     protected function removeImplementations(Index $index, ClassRecord $record): void
@@ -52,7 +53,7 @@ abstract class AbstractClassLikeIndexer implements TolerantIndexer
         }
     }
 
-    protected function getClassLikeRecord(string $type, Node $node, Index $index, SplFileInfo $info): ClassRecord
+    protected function getClassLikeRecord(string $type, Node $node, Index $index, TextDocument $document): ClassRecord
     {
         assert($node instanceof NamespacedNameInterface);
         $name = $node->getNamespacedName()->getFullyQualifiedNameText();
@@ -60,14 +61,14 @@ abstract class AbstractClassLikeIndexer implements TolerantIndexer
         if (empty($name)) {
             throw new CannotIndexNode(sprintf(
                 'Name is empty for file "%s"',
-                $info->getPathname()
+                $document->uri()->path()
             ));
         }
 
         $record = $index->get(ClassRecord::fromName($name));
         assert($record instanceof ClassRecord);
         $record->setStart(ByteOffset::fromInt($node->getStart()));
-        $record->setFilePath($info->getPathname());
+        $record->setFilePath($document->uri()->path());
         $record->setType($type);
 
         return $record;

--- a/lib/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
@@ -7,7 +7,6 @@ use Phpactor\Indexer\Model\Name\FullyQualifiedName;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
 use Phpactor\TextDocument\TextDocument;
-use SplFileInfo;
 use Phpactor\Indexer\Model\Index;
 
 class ClassDeclarationIndexer extends AbstractClassLikeIndexer

--- a/lib/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Phpactor\Indexer\Model\Name\FullyQualifiedName;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
+use Phpactor\TextDocument\TextDocument;
 use SplFileInfo;
 use Phpactor\Indexer\Model\Index;
 
@@ -16,10 +17,10 @@ class ClassDeclarationIndexer extends AbstractClassLikeIndexer
         return $node instanceof ClassDeclaration;
     }
 
-    public function index(Index $index, SplFileInfo $info, Node $node): void
+    public function index(Index $index, TextDocument $document, Node $node): void
     {
         assert($node instanceof ClassDeclaration);
-        $record = $this->getClassLikeRecord('class', $node, $index, $info);
+        $record = $this->getClassLikeRecord('class', $node, $index, $document);
 
         $this->removeImplementations($index, $record);
         $record->clearImplemented();

--- a/lib/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
@@ -11,7 +11,6 @@ use Phpactor\Indexer\Model\RecordReference;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\Indexer\Model\Record\FileRecord;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Patch\TolerantQualifiedNameResolver;
-use SplFileInfo;
 use Phpactor\TextDocument\TextDocument;
 
 class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer

--- a/lib/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
@@ -13,7 +13,6 @@ use Microsoft\PhpParser\Node\StringLiteral;
 use Phpactor\Indexer\Adapter\Tolerant\TolerantIndexer;
 use Phpactor\Indexer\Model\Record\ConstantRecord;
 use Phpactor\TextDocument\ByteOffset;
-use SplFileInfo;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\TextDocument\TextDocument;
 

--- a/lib/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
@@ -15,6 +15,7 @@ use Phpactor\Indexer\Model\Record\ConstantRecord;
 use Phpactor\TextDocument\ByteOffset;
 use SplFileInfo;
 use Phpactor\Indexer\Model\Index;
+use Phpactor\TextDocument\TextDocument;
 
 class ConstantDeclarationIndexer implements TolerantIndexer
 {
@@ -41,24 +42,24 @@ class ConstantDeclarationIndexer implements TolerantIndexer
         return false;
     }
 
-    public function index(Index $index, SplFileInfo $info, Node $node): void
+    public function index(Index $index, TextDocument $document, Node $node): void
     {
         if ($node instanceof ConstDeclaration) {
-            $this->fromConstDeclaration($node, $index, $info);
+            $this->fromConstDeclaration($node, $index, $document);
             return;
         }
 
         if ($node instanceof CallExpression) {
-            $this->fromDefine($node, $index, $info);
+            $this->fromDefine($node, $index, $document);
             return;
         }
     }
 
-    public function beforeParse(Index $index, SplFileInfo $info): void
+    public function beforeParse(Index $index, TextDocument $document): void
     {
     }
 
-    private function fromConstDeclaration(Node $node, Index $index, SplFileInfo $info): void
+    private function fromConstDeclaration(Node $node, Index $index, TextDocument $document): void
     {
         assert($node instanceof ConstDeclaration);
         if (!$node->constElements instanceof ConstElementList) {
@@ -69,12 +70,12 @@ class ConstantDeclarationIndexer implements TolerantIndexer
             $record = $index->get(ConstantRecord::fromName($constNode->getNamespacedName()->getFullyQualifiedNameText()));
             assert($record instanceof ConstantRecord);
             $record->setStart(ByteOffset::fromInt($node->getStart()));
-            $record->setFilePath($info->getPathname());
+            $record->setFilePath($document->uri()->path());
             $index->write($record);
         }
     }
 
-    private function fromDefine(CallExpression $node, Index $index, SplFileInfo $info): void
+    private function fromDefine(CallExpression $node, Index $index, TextDocument $document): void
     {
         assert($node instanceof CallExpression);
 
@@ -94,7 +95,7 @@ class ConstantDeclarationIndexer implements TolerantIndexer
             $record = $index->get(ConstantRecord::fromName($string->getStringContentsText()));
             assert($record instanceof ConstantRecord);
             $record->setStart(ByteOffset::fromInt($node->getStart()));
-            $record->setFilePath($info->getPathname());
+            $record->setFilePath($document->uri()->path());
             $index->write($record);
         }
     }

--- a/lib/Adapter/Tolerant/Indexer/FunctionDeclarationIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/FunctionDeclarationIndexer.php
@@ -9,7 +9,6 @@ use Phpactor\Indexer\Model\Index;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\Indexer\Model\Record\FunctionRecord;
 use Phpactor\TextDocument\TextDocument;
-use SplFileInfo;
 
 class FunctionDeclarationIndexer implements TolerantIndexer
 {

--- a/lib/Adapter/Tolerant/Indexer/FunctionDeclarationIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/FunctionDeclarationIndexer.php
@@ -8,6 +8,7 @@ use Phpactor\Indexer\Adapter\Tolerant\TolerantIndexer;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\Indexer\Model\Record\FunctionRecord;
+use Phpactor\TextDocument\TextDocument;
 use SplFileInfo;
 
 class FunctionDeclarationIndexer implements TolerantIndexer
@@ -17,17 +18,17 @@ class FunctionDeclarationIndexer implements TolerantIndexer
         return $node instanceof FunctionDeclaration;
     }
 
-    public function index(Index $index, SplFileInfo $info, Node $node): void
+    public function index(Index $index, TextDocument $document, Node $node): void
     {
         assert($node instanceof FunctionDeclaration);
         $record = $index->get(FunctionRecord::fromName($node->getNamespacedName()->getFullyQualifiedNameText()));
         assert($record instanceof FunctionRecord);
         $record->setStart(ByteOffset::fromInt($node->getStart()));
-        $record->setFilePath($info->getPathname());
+        $record->setFilePath($document->uri()->path());
         $index->write($record);
     }
 
-    public function beforeParse(Index $index, SplFileInfo $info): void
+    public function beforeParse(Index $index, TextDocument $document): void
     {
     }
 }

--- a/lib/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
@@ -9,7 +9,6 @@ use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\RecordReference;
 use Phpactor\Indexer\Model\Record\FileRecord;
 use Phpactor\Indexer\Model\Record\FunctionRecord;
-use SplFileInfo;
 use Phpactor\TextDocument\TextDocument;
 
 class FunctionReferenceIndexer extends AbstractClassLikeIndexer

--- a/lib/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
@@ -10,6 +10,7 @@ use Phpactor\Indexer\Model\RecordReference;
 use Phpactor\Indexer\Model\Record\FileRecord;
 use Phpactor\Indexer\Model\Record\FunctionRecord;
 use SplFileInfo;
+use Phpactor\TextDocument\TextDocument;
 
 class FunctionReferenceIndexer extends AbstractClassLikeIndexer
 {
@@ -18,9 +19,9 @@ class FunctionReferenceIndexer extends AbstractClassLikeIndexer
         return $node instanceof QualifiedName && $node->parent instanceof CallExpression;
     }
 
-    public function beforeParse(Index $index, SplFileInfo $info): void
+    public function beforeParse(Index $index, TextDocument $document): void
     {
-        $fileRecord = $index->get(FileRecord::fromFileInfo($info));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
         assert($fileRecord instanceof FileRecord);
 
         foreach ($fileRecord->references() as $outgoingReference) {
@@ -35,7 +36,7 @@ class FunctionReferenceIndexer extends AbstractClassLikeIndexer
         }
     }
 
-    public function index(Index $index, SplFileInfo $info, Node $node): void
+    public function index(Index $index, TextDocument $document, Node $node): void
     {
         assert($node instanceof QualifiedName);
 
@@ -48,10 +49,10 @@ class FunctionReferenceIndexer extends AbstractClassLikeIndexer
 
         $targetRecord = $index->get(FunctionRecord::fromName($name));
         assert($targetRecord instanceof FunctionRecord);
-        $targetRecord->addReference($info->getPathname());
+        $targetRecord->addReference($document->uri()->path());
         $index->write($targetRecord);
 
-        $fileRecord = $index->get(FileRecord::fromFileInfo($info));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
         assert($fileRecord instanceof FileRecord);
         $fileRecord->addReference(new RecordReference(FunctionRecord::RECORD_TYPE, $targetRecord->identifier(), $node->getStart()));
         $index->write($fileRecord);

--- a/lib/Adapter/Tolerant/Indexer/InterfaceDeclarationIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/InterfaceDeclarationIndexer.php
@@ -7,7 +7,6 @@ use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\TextDocument\TextDocument;
-use SplFileInfo;
 
 class InterfaceDeclarationIndexer extends AbstractClassLikeIndexer
 {

--- a/lib/Adapter/Tolerant/Indexer/InterfaceDeclarationIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/InterfaceDeclarationIndexer.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\Indexer\Model\Index;
+use Phpactor\TextDocument\TextDocument;
 use SplFileInfo;
 
 class InterfaceDeclarationIndexer extends AbstractClassLikeIndexer
@@ -15,10 +16,10 @@ class InterfaceDeclarationIndexer extends AbstractClassLikeIndexer
         return $node instanceof InterfaceDeclaration;
     }
 
-    public function index(Index $index, SplFileInfo $info, Node $node): void
+    public function index(Index $index, TextDocument $document, Node $node): void
     {
         assert($node instanceof InterfaceDeclaration);
-        $record = $this->getClassLikeRecord('interface', $node, $index, $info);
+        $record = $this->getClassLikeRecord('interface', $node, $index, $document);
 
         // remove any references to this interface and other classes before
         // updating with the current data

--- a/lib/Adapter/Tolerant/Indexer/MemberIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/MemberIndexer.php
@@ -15,7 +15,6 @@ use Phpactor\Indexer\Model\MemberReference;
 use Phpactor\Indexer\Model\RecordReference;
 use Phpactor\Indexer\Model\Record\FileRecord;
 use Phpactor\Indexer\Model\Record\MemberRecord;
-use SplFileInfo;
 use Phpactor\TextDocument\TextDocument;
 
 class MemberIndexer implements TolerantIndexer

--- a/lib/Adapter/Tolerant/Indexer/MemberIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/MemberIndexer.php
@@ -16,6 +16,7 @@ use Phpactor\Indexer\Model\RecordReference;
 use Phpactor\Indexer\Model\Record\FileRecord;
 use Phpactor\Indexer\Model\Record\MemberRecord;
 use SplFileInfo;
+use Phpactor\TextDocument\TextDocument;
 
 class MemberIndexer implements TolerantIndexer
 {
@@ -24,9 +25,9 @@ class MemberIndexer implements TolerantIndexer
         return $node instanceof ScopedPropertyAccessExpression || $node instanceof MemberAccessExpression;
     }
 
-    public function beforeParse(Index $index, SplFileInfo $info): void
+    public function beforeParse(Index $index, TextDocument $document): void
     {
-        $fileRecord = $index->get(FileRecord::fromFileInfo($info));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
         assert($fileRecord instanceof FileRecord);
 
         foreach ($fileRecord->references() as $outgoingReference) {
@@ -43,20 +44,20 @@ class MemberIndexer implements TolerantIndexer
         }
     }
 
-    public function index(Index $index, SplFileInfo $info, Node $node): void
+    public function index(Index $index, TextDocument $document, Node $node): void
     {
         if ($node instanceof ScopedPropertyAccessExpression) {
-            $this->indexScopedPropertyAccess($index, $info, $node);
+            $this->indexScopedPropertyAccess($index, $document, $node);
             return;
         }
 
         if ($node instanceof MemberAccessExpression) {
-            $this->indexMemberAccessExpression($index, $info, $node);
+            $this->indexMemberAccessExpression($index, $document, $node);
             return;
         }
     }
 
-    private function indexScopedPropertyAccess(Index $index, SplFileInfo $info, ScopedPropertyAccessExpression $node): void
+    private function indexScopedPropertyAccess(Index $index, TextDocument $document, ScopedPropertyAccessExpression $node): void
     {
         $containerType = $node->scopeResolutionQualifier;
 
@@ -73,7 +74,7 @@ class MemberIndexer implements TolerantIndexer
 
         $memberType = $this->resolveScopedPropertyAccessMemberType($node);
 
-        $this->writeIndex($index, $memberType, $containerType, $memberName, $info, $this->resolveStart($node->memberName));
+        $this->writeIndex($index, $memberType, $containerType, $memberName, $document, $this->resolveStart($node->memberName));
     }
 
     private function resolveScopedPropertyAccessMemberType(ScopedPropertyAccessExpression $node): string
@@ -113,7 +114,7 @@ class MemberIndexer implements TolerantIndexer
         return (string)$memberName->getName();
     }
 
-    private function indexMemberAccessExpression(Index $index, SplFileInfo $info, MemberAccessExpression $node): void
+    private function indexMemberAccessExpression(Index $index, TextDocument $document, MemberAccessExpression $node): void
     {
         $memberName = $node->memberName;
 
@@ -130,17 +131,17 @@ class MemberIndexer implements TolerantIndexer
 
         $memberType = $this->resolveMemberAccessType($node);
 
-        $this->writeIndex($index, $memberType, null, (string)$memberName, $info, $this->resolveStart($node->memberName));
+        $this->writeIndex($index, $memberType, null, (string)$memberName, $document, $this->resolveStart($node->memberName));
     }
 
-    private function writeIndex(Index $index, string $memberType, ?string $containerFqn, string $memberName, SplFileInfo $info, int $offsetStart): void
+    private function writeIndex(Index $index, string $memberType, ?string $containerFqn, string $memberName, TextDocument $document, int $offsetStart): void
     {
         $record = $index->get(MemberRecord::fromMemberReference(MemberReference::create($memberType, $containerFqn, $memberName)));
         assert($record instanceof MemberRecord);
-        $record->addReference($info->getPathname());
+        $record->addReference($document->uri()->path());
         $index->write($record);
         
-        $fileRecord = $index->get(FileRecord::fromFileInfo($info));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
         assert($fileRecord instanceof FileRecord);
         $fileRecord->addReference(RecordReference::fromRecordAndOffsetAndContainerType($record, $offsetStart, $containerFqn));
         $index->write($fileRecord);

--- a/lib/Adapter/Tolerant/Indexer/TraitDeclarationIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/TraitDeclarationIndexer.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
 use Phpactor\Indexer\Model\Index;
 use SplFileInfo;
+use Phpactor\TextDocument\TextDocument;
 
 class TraitDeclarationIndexer extends AbstractClassLikeIndexer
 {
@@ -14,10 +15,10 @@ class TraitDeclarationIndexer extends AbstractClassLikeIndexer
         return $node instanceof TraitDeclaration;
     }
 
-    public function index(Index $index, SplFileInfo $info, Node $node): void
+    public function index(Index $index, TextDocument $document, Node $node): void
     {
         assert($node instanceof TraitDeclaration);
-        $record = $this->getClassLikeRecord('trait', $node, $index, $info);
+        $record = $this->getClassLikeRecord('trait', $node, $index, $document);
         $index->write($record);
     }
 }

--- a/lib/Adapter/Tolerant/Indexer/TraitDeclarationIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/TraitDeclarationIndexer.php
@@ -5,7 +5,6 @@ namespace Phpactor\Indexer\Adapter\Tolerant\Indexer;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
 use Phpactor\Indexer\Model\Index;
-use SplFileInfo;
 use Phpactor\TextDocument\TextDocument;
 
 class TraitDeclarationIndexer extends AbstractClassLikeIndexer

--- a/lib/Adapter/Tolerant/Indexer/TraitUseClauseIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/TraitUseClauseIndexer.php
@@ -11,7 +11,6 @@ use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\Name\FullyQualifiedName;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Patch\TolerantQualifiedNameResolver;
-use SplFileInfo;
 use Phpactor\TextDocument\TextDocument;
 
 class TraitUseClauseIndexer implements TolerantIndexer

--- a/lib/Adapter/Tolerant/Indexer/TraitUseClauseIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/TraitUseClauseIndexer.php
@@ -12,6 +12,7 @@ use Phpactor\Indexer\Model\Name\FullyQualifiedName;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Patch\TolerantQualifiedNameResolver;
 use SplFileInfo;
+use Phpactor\TextDocument\TextDocument;
 
 class TraitUseClauseIndexer implements TolerantIndexer
 {
@@ -20,7 +21,7 @@ class TraitUseClauseIndexer implements TolerantIndexer
         return $node instanceof TraitUseClause;
     }
 
-    public function index(Index $index, SplFileInfo $info, Node $node): void
+    public function index(Index $index, TextDocument $document, Node $node): void
     {
         assert($node instanceof TraitUseClause);
 
@@ -52,7 +53,7 @@ class TraitUseClauseIndexer implements TolerantIndexer
         }
     }
 
-    public function beforeParse(Index $index, SplFileInfo $info): void
+    public function beforeParse(Index $index, TextDocument $document): void
     {
     }
 }

--- a/lib/Adapter/Tolerant/TolerantIndexBuilder.php
+++ b/lib/Adapter/Tolerant/TolerantIndexBuilder.php
@@ -16,6 +16,7 @@ use Phpactor\Indexer\Adapter\Tolerant\Indexer\TraitUseClauseIndexer;
 use Phpactor\Indexer\Model\Exception\CannotIndexNode;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\IndexBuilder;
+use Phpactor\TextDocument\TextDocument;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SplFileInfo;
@@ -76,20 +77,14 @@ final class TolerantIndexBuilder implements IndexBuilder
         );
     }
 
-    public function index(SplFileInfo $info): void
+    public function index(TextDocument $document): void
     {
-        $contents = @file_get_contents($info->getPathname());
-
-        if (false === $contents) {
-            return;
-        }
-
         foreach ($this->indexers as $indexer) {
-            $indexer->beforeParse($this->index, $info);
+            $indexer->beforeParse($this->index, $document);
         }
 
-        $node = $this->parser->parseSourceFile($contents, $info->getPathname());
-        $this->indexNode($info, $node);
+        $node = $this->parser->parseSourceFile($document->__toString(), $document->uri()->path());
+        $this->indexNode($document, $node);
     }
 
     public function done(): void
@@ -97,25 +92,25 @@ final class TolerantIndexBuilder implements IndexBuilder
         $this->index->done();
     }
 
-    private function indexNode(SplFileInfo $info, Node $node): void
+    private function indexNode(TextDocument $document, Node $node): void
     {
         foreach ($this->indexers as $indexer) {
             try {
                 if ($indexer->canIndex($node)) {
-                    $indexer->index($this->index, $info, $node);
+                    $indexer->index($this->index, $document, $node);
                 }
             } catch (CannotIndexNode $cannotIndexNode) {
                 $this->logger->warning(sprintf(
                     'Cannot index node of class "%s" in file "%s": %s',
                     get_class($node),
-                    $info->getPathname(),
+                    $document->uri()->__toString(),
                     $cannotIndexNode->getMessage()
                 ));
             }
         }
 
         foreach ($node->getChildNodes() as $childNode) {
-            $this->indexNode($info, $childNode);
+            $this->indexNode($document, $childNode);
         }
     }
 }

--- a/lib/Adapter/Tolerant/TolerantIndexBuilder.php
+++ b/lib/Adapter/Tolerant/TolerantIndexBuilder.php
@@ -19,7 +19,6 @@ use Phpactor\Indexer\Model\IndexBuilder;
 use Phpactor\TextDocument\TextDocument;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use SplFileInfo;
 
 final class TolerantIndexBuilder implements IndexBuilder
 {

--- a/lib/Adapter/Tolerant/TolerantIndexer.php
+++ b/lib/Adapter/Tolerant/TolerantIndexer.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Indexer\Adapter\Tolerant;
 
 use Microsoft\PhpParser\Node;
+use Phpactor\TextDocument\TextDocument;
 use SplFileInfo;
 use Phpactor\Indexer\Model\Index;
 
@@ -10,7 +11,7 @@ interface TolerantIndexer
 {
     public function canIndex(Node $node): bool;
 
-    public function index(Index $index, SplFileInfo $info, Node $node): void;
+    public function index(Index $index, TextDocument $document, Node $node): void;
 
-    public function beforeParse(Index $index, SplFileInfo $info): void;
+    public function beforeParse(Index $index, TextDocument $document): void;
 }

--- a/lib/Adapter/Tolerant/TolerantIndexer.php
+++ b/lib/Adapter/Tolerant/TolerantIndexer.php
@@ -4,7 +4,6 @@ namespace Phpactor\Indexer\Adapter\Tolerant;
 
 use Microsoft\PhpParser\Node;
 use Phpactor\TextDocument\TextDocument;
-use SplFileInfo;
 use Phpactor\Indexer\Model\Index;
 
 interface TolerantIndexer

--- a/lib/IndexAgentBuilder.php
+++ b/lib/IndexAgentBuilder.php
@@ -219,7 +219,7 @@ final class IndexAgentBuilder
             $builder,
             $index,
             $this->buildFileListProvider(),
-            new DirtyFileListProvider($this->indexRoot . '/dirty')
+            $this->buildDirtyTracker()
         );
     }
 
@@ -260,6 +260,13 @@ final class IndexAgentBuilder
             );
         }
 
+        $providers[] = $this->buildDirtyTracker();
+
         return $providers;
+    }
+
+    private function buildDirtyTracker(): DirtyFileListProvider
+    {
+        return new DirtyFileListProvider($this->indexRoot . '/dirty');
     }
 }

--- a/lib/IndexAgentBuilder.php
+++ b/lib/IndexAgentBuilder.php
@@ -13,6 +13,7 @@ use Phpactor\Indexer\Adapter\Tolerant\TolerantIndexBuilder;
 use Phpactor\Indexer\Adapter\Tolerant\TolerantIndexer;
 use Phpactor\Indexer\Model\FileListProvider;
 use Phpactor\Indexer\Model\FileListProvider\ChainFileListProvider;
+use Phpactor\Indexer\Model\FileListProvider\DirtyFileListProvider;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\IndexAccess;
 use Phpactor\Indexer\Model\Index\SearchAwareIndex;
@@ -214,7 +215,12 @@ final class IndexAgentBuilder
 
     private function buildIndexer(IndexBuilder $builder, Index $index): Indexer
     {
-        return new Indexer($builder, $index, $this->buildFileListProvider());
+        return new Indexer(
+            $builder,
+            $index,
+            $this->buildFileListProvider(),
+            new DirtyFileListProvider($this->indexRoot . '/dirty')
+        );
     }
 
     private function buildFileListProvider(): FileListProvider

--- a/lib/Model/DirtyDocumentTracker.php
+++ b/lib/Model/DirtyDocumentTracker.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Phpactor\Indexer\Model;
+
+use Phpactor\TextDocument\TextDocumentUri;
+
+interface DirtyDocumentTracker
+{
+    public function markDirty(TextDocumentUri $uri): void;
+}

--- a/lib/Model/DirtyDocumentTracker/NullDirtyDocumentTracker.php
+++ b/lib/Model/DirtyDocumentTracker/NullDirtyDocumentTracker.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phpactor\Indexer\Model\DirtyDocumentTracker;
+
+use Phpactor\Indexer\Model\DirtyDocumentTracker;
+use Phpactor\TextDocument\TextDocumentUri;
+
+class NullDirtyDocumentTracker implements DirtyDocumentTracker
+{
+    public function markDirty(TextDocumentUri $uri): void
+    {
+    }
+}

--- a/lib/Model/FileListProvider/DirtyFileListProvider.php
+++ b/lib/Model/FileListProvider/DirtyFileListProvider.php
@@ -7,7 +7,6 @@ use Phpactor\Indexer\Model\DirtyDocumentTracker;
 use Phpactor\Indexer\Model\FileList;
 use Phpactor\Indexer\Model\FileListProvider;
 use Phpactor\Indexer\Model\Index;
-use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextDocumentUri;
 use RuntimeException;
 use SplFileInfo;
@@ -19,6 +18,9 @@ class DirtyFileListProvider implements FileListProvider, DirtyDocumentTracker
      */
     private $dirtyPath;
 
+    /**
+     * @var array<string, bool>
+     */
     private $seen = [];
 
     public function __construct(string $dirtyPath)
@@ -31,6 +33,7 @@ class DirtyFileListProvider implements FileListProvider, DirtyDocumentTracker
         if (isset($this->seen[$uri->path()])) {
             return;
         }
+
         $handle = @fopen($this->dirtyPath, 'a');
         if (false === $handle) {
             throw new RuntimeException(sprintf(
@@ -48,6 +51,9 @@ class DirtyFileListProvider implements FileListProvider, DirtyDocumentTracker
         return FileList::fromInfoIterator($this->paths());
     }
 
+    /**
+     * @return Generator<SplFileInfo>
+     */
     private function paths(): Generator
     {
         $contents = @file_get_contents($this->dirtyPath);

--- a/lib/Model/FileListProvider/DirtyFileListProvider.php
+++ b/lib/Model/FileListProvider/DirtyFileListProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Phpactor\Indexer\Model\FileListProvider;
+
+use Generator;
+use Phpactor\Indexer\Model\DirtyDocumentTracker;
+use Phpactor\Indexer\Model\FileList;
+use Phpactor\Indexer\Model\FileListProvider;
+use Phpactor\Indexer\Model\Index;
+use Phpactor\TextDocument\TextDocument;
+use Phpactor\TextDocument\TextDocumentUri;
+use SplFileInfo;
+
+class DirtyFileListProvider implements FileListProvider, DirtyDocumentTracker
+{
+    /**
+     * @var string
+     */
+    private $dirtyPath;
+
+    public function __construct(string $dirtyPath)
+    {
+        $this->dirtyPath = $dirtyPath;
+    }
+
+    public function markDirty(TextDocumentUri $uri): void
+    {
+        $handle = fopen($this->dirtyPath, 'a');
+        fwrite($handle, $uri->path() . "\n");
+        fclose($handle);
+    }
+
+    public function provideFileList(Index $index, ?string $subPath = null): FileList
+    {
+        return FileList::fromInfoIterator($this->paths());
+    }
+
+    private function paths(): Generator
+    {
+        $contents = @file_get_contents($this->dirtyPath);
+        if (false === $contents) {
+            return;
+        }
+
+        $paths = explode("\n", $contents);
+        foreach ($paths as $path) {
+            if (!file_exists($path)) {
+                continue;
+            }
+            yield new SplFileInfo($path);
+        }
+
+        unlink($this->dirtyPath);
+    }
+}

--- a/lib/Model/IndexBuilder.php
+++ b/lib/Model/IndexBuilder.php
@@ -3,7 +3,6 @@
 namespace Phpactor\Indexer\Model;
 
 use Phpactor\TextDocument\TextDocument;
-use SplFileInfo;
 
 interface IndexBuilder
 {

--- a/lib/Model/IndexBuilder.php
+++ b/lib/Model/IndexBuilder.php
@@ -2,11 +2,12 @@
 
 namespace Phpactor\Indexer\Model;
 
+use Phpactor\TextDocument\TextDocument;
 use SplFileInfo;
 
 interface IndexBuilder
 {
-    public function index(SplFileInfo $info): void;
+    public function index(TextDocument $document): void;
 
     public function done(): void;
 }

--- a/lib/Model/IndexJob.php
+++ b/lib/Model/IndexJob.php
@@ -4,8 +4,6 @@ namespace Phpactor\Indexer\Model;
 
 use Generator;
 use Phpactor\TextDocument\TextDocumentBuilder;
-use Phpactor\TextDocument\TextDocumentLocator;
-use Phpactor\TextDocument\TextDocumentUri;
 use SplFileInfo;
 
 class IndexJob

--- a/lib/Model/IndexJob.php
+++ b/lib/Model/IndexJob.php
@@ -3,6 +3,10 @@
 namespace Phpactor\Indexer\Model;
 
 use Generator;
+use Phpactor\TextDocument\TextDocumentBuilder;
+use Phpactor\TextDocument\TextDocumentLocator;
+use Phpactor\TextDocument\TextDocumentUri;
+use SplFileInfo;
 
 class IndexJob
 {
@@ -28,7 +32,16 @@ class IndexJob
     public function generator(): Generator
     {
         foreach ($this->fileList as $fileInfo) {
-            $this->indexBuilder->index($fileInfo);
+            assert($fileInfo instanceof SplFileInfo);
+            $contents = @file_get_contents($fileInfo->getPathname());
+
+            if (false === $contents) {
+                continue;
+            }
+
+            $this->indexBuilder->index(
+                TextDocumentBuilder::create($contents)->uri($fileInfo->getPathname())->build()
+            );
             yield $fileInfo->getPathname();
         }
         $this->indexBuilder->done();

--- a/lib/Model/Indexer.php
+++ b/lib/Model/Indexer.php
@@ -3,9 +3,7 @@
 namespace Phpactor\Indexer\Model;
 
 use Phpactor\Indexer\Model\DirtyDocumentTracker\NullDirtyDocumentTracker;
-use Phpactor\Indexer\Model\FileListProvider\DirtyFileListProvider;
 use Phpactor\TextDocument\TextDocument;
-use SplFileInfo;
 
 class Indexer
 {

--- a/lib/Model/Indexer.php
+++ b/lib/Model/Indexer.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Indexer\Model;
 
+use Phpactor\TextDocument\TextDocument;
 use SplFileInfo;
 
 class Indexer
@@ -36,9 +37,9 @@ class Indexer
         );
     }
 
-    public function index(SplFileInfo $file): void
+    public function index(TextDocument $textDocument): void
     {
-        $this->builder->index($file);
+        $this->builder->index($textDocument);
     }
 
     public function reset(): void

--- a/tests/Unit/Model/FileListProvider/DirtyFileListProviderTest.php
+++ b/tests/Unit/Model/FileListProvider/DirtyFileListProviderTest.php
@@ -33,11 +33,14 @@ class DirtyFileListProviderTest extends IntegrationTestCase
         $this->workspace()->put(self::EXAMPLE_FILE_1, '');
         $tracker->markDirty(TextDocumentUri::fromString($this->workspace()->path(self::EXAMPLE_FILE_1)));
 
+        self::assertFileExists($this->workspace()->path('dirty'));
+
         $files = $tracker->provideFileList(new InMemoryIndex([]));
         self::assertCount(1, $files);
 
         $files = $tracker->provideFileList(new InMemoryIndex([]));
         self::assertCount(0, $files);
+        self::assertFileDoesNotExist($this->workspace()->path('dirty'));
     }
 
     public function testDoNotDuplicate(): void

--- a/tests/Unit/Model/FileListProvider/DirtyFileListProviderTest.php
+++ b/tests/Unit/Model/FileListProvider/DirtyFileListProviderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Phpactor\Indexer\Tests\Unit\Model\FileListProvider;
+
+use Phpactor\Indexer\Adapter\Php\InMemory\InMemoryIndex;
+use Phpactor\Indexer\Model\FileListProvider\DirtyFileListProvider;
+use Phpactor\Indexer\Tests\IntegrationTestCase;
+use Phpactor\TextDocument\TextDocumentUri;
+use RuntimeException;
+
+class DirtyFileListProviderTest extends IntegrationTestCase
+{
+    const EXAMPLE_FILE_1 = 'foobar';
+    const EXAMPLE_FILE_2 = 'barfoo';
+
+
+    public function testTrackAndProvideDirtyDocuments(): void
+    {
+        $tracker = $this->createProvider();
+        $this->workspace()->put(self::EXAMPLE_FILE_1, '');
+        $this->workspace()->put(self::EXAMPLE_FILE_2, '');
+        $tracker->markDirty(TextDocumentUri::fromString($this->workspace()->path(self::EXAMPLE_FILE_1)));
+        $tracker->markDirty(TextDocumentUri::fromString($this->workspace()->path(self::EXAMPLE_FILE_2)));
+
+        $files = $tracker->provideFileList(new InMemoryIndex([]));
+
+        self::assertCount(2, $files);
+    }
+
+    public function testReleasedDirtyFilesAreNoLongerTracked(): void
+    {
+        $tracker = $this->createProvider();
+        $this->workspace()->put(self::EXAMPLE_FILE_1, '');
+        $tracker->markDirty(TextDocumentUri::fromString($this->workspace()->path(self::EXAMPLE_FILE_1)));
+
+        $files = $tracker->provideFileList(new InMemoryIndex([]));
+        self::assertCount(1, $files);
+
+        $files = $tracker->provideFileList(new InMemoryIndex([]));
+        self::assertCount(0, $files);
+    }
+
+    public function testDoNotDuplicate(): void
+    {
+        $tracker = $this->createProvider();
+        $this->workspace()->put(self::EXAMPLE_FILE_1, '');
+        $this->workspace()->put(self::EXAMPLE_FILE_2, '');
+        $tracker->markDirty(TextDocumentUri::fromString($this->workspace()->path(self::EXAMPLE_FILE_1)));
+        $tracker->markDirty(TextDocumentUri::fromString($this->workspace()->path(self::EXAMPLE_FILE_2)));
+        $tracker->markDirty(TextDocumentUri::fromString($this->workspace()->path(self::EXAMPLE_FILE_2)));
+        $tracker->markDirty(TextDocumentUri::fromString($this->workspace()->path(self::EXAMPLE_FILE_2)));
+
+        $files = $tracker->provideFileList(new InMemoryIndex([]));
+
+        self::assertCount(2, $files);
+    }
+
+    public function testNonExistingFile(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Dirty index');
+        $tracker = $this->createProvider('foobar/no');
+        $tracker->markDirty(TextDocumentUri::fromString($this->workspace()->path(self::EXAMPLE_FILE_1)));
+    }
+
+    private function createProvider(string $path = 'dirty'): DirtyFileListProvider
+    {
+        $tracker = new DirtyFileListProvider($this->workspace()->path($path));
+        return $tracker;
+    }
+}


### PR DESCRIPTION
Add ability to index files which may not be persisted to the disk yet.

- Each "dirty" file will be tagged and reindexed when the language server is retarted, refreshing it's state from the disk.